### PR TITLE
To prevent `chunked` encoding breaking surrogate pairs, populate self…

### DIFF
--- a/lib/XMLHttpRequest.js
+++ b/lib/XMLHttpRequest.js
@@ -462,7 +462,6 @@ function XMLHttpRequest(opts) {
           // Make sure there's some data
           if (chunk) {
             var data = Buffer.from(chunk);
-            self.responseText += data.toString('utf8');
             self.response = Buffer.concat([self.response, data]);
           }
           // Don't emit state changes if the connection has been aborted.
@@ -478,6 +477,8 @@ function XMLHttpRequest(opts) {
             sendFlag = false;
             // Discard the 'end' event if the connection has been aborted
             setState(self.DONE);
+            // Construct responseText from response
+            self.responseText = self.response.toString('utf8');
           }
         });
 


### PR DESCRIPTION
….responseText only once, after self.response has been fully reassembled.

Co-authored-by: Paul Ringseth <paul@distributive.network>